### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,37 +9,37 @@ matrix:
     # Exclude default job which lacks our included environment variables.
     - os: osx
   include:
-    - osx_image: xcode8
-      env:
-        - XCODE_SDK=macosx
-          XCODE_ACTION=test
-          XCODE_DESTINATION="arch=x86_64"
-    - osx_image: xcode8.1
-      env:
-        - XCODE_SDK=macosx
-          XCODE_ACTION=test
-          XCODE_DESTINATION="arch=x86_64"
     - osx_image: xcode8.2
       env:
         - XCODE_SDK=macosx
           XCODE_ACTION=test
           XCODE_DESTINATION="arch=x86_64"
-    - osx_image: xcode8
+    - osx_image: xcode8.3
+      env:
+        - XCODE_SDK=macosx
+          XCODE_ACTION=test
+          XCODE_DESTINATION="arch=x86_64"
+    - osx_image: xcode9
+      env:
+        - XCODE_SDK=macosx
+          XCODE_ACTION=test
+          XCODE_DESTINATION="arch=x86_64"
+    - osx_image: xcode8.3
       env:
         - XCODE_SDK=iphonesimulator
           XCODE_ACTION="build-for-testing test-without-building"
           XCODE_DESTINATION="name=iPhone 6s"
-    - osx_image: xcode8
+    - osx_image: xcode8.3
       env:
         - XCODE_SDK=appletvsimulator
           XCODE_ACTION="build-for-testing test-without-building"
           XCODE_DESTINATION="name=Apple TV 1080p"
-    - osx_image: xcode8
+    - osx_image: xcode8.3
       env:
         - XCODE_SDK=watchsimulator
           XCODE_ACTION=build
           XCODE_DESTINATION="name=Apple Watch - 38mm"
-    - osx_image: xcode8
+    - osx_image: xcode8.3
       env:
         - JOB=CARTHAGE
       script:
@@ -47,61 +47,48 @@ matrix:
         - brew outdated carthage || brew upgrade carthage
         - carthage build --no-skip-current
         - for platform in Mac iOS tvOS watchOS; do test -d Carthage/Build/${platform}/PrettyColors.framework || exit 1; done
-    - osx_image: xcode8
-      env:
-        - JOB=SWIFT_PM
-      script:
-        - swift build --verbose
-        - swift test
-    - osx_image: xcode8.1
-      env:
-        - JOB=SWIFT_PM
-      script:
-        - swift build --verbose
-        - swift test
     - osx_image: xcode8.2
       env:
         - JOB=SWIFT_PM
+      git:
+        submodules: false
       script:
         - swift build --verbose
         - swift test
-    - os: linux
-      language: generic
-      sudo: required
-      dist: trusty
+    - osx_image: xcode8.3
       env:
-        - SWIFT_VERSION="3.0"
-      before_install:
-        - eval "$(curl -sL https://gist.githubusercontent.com/kylef/5c0475ff02b7c7671d2a/raw/9f442512a46d7a2af7b850d65a7e9bd31edfb09b/swiftenv-install.sh)"
+        - JOB=SWIFT_PM
+      git:
+        submodules: false
       script:
         - swift build --verbose
-        - swift test || true
-    - os: linux
-      language: generic
-      sudo: required
-      dist: trusty
-      env:
-        - SWIFT_VERSION="3.0.1"
-      before_install:
-        - eval "$(curl -sL https://gist.githubusercontent.com/kylef/5c0475ff02b7c7671d2a/raw/9f442512a46d7a2af7b850d65a7e9bd31edfb09b/swiftenv-install.sh)"
-      script:
-        - swift build --verbose
-        - swift test || true
+        - swift test
     - os: linux
       language: generic
       sudo: required
       dist: trusty
       env:
         - SWIFT_VERSION="3.0.2"
+      git:
+        submodules: false
       before_install:
         - eval "$(curl -sL https://gist.githubusercontent.com/kylef/5c0475ff02b7c7671d2a/raw/9f442512a46d7a2af7b850d65a7e9bd31edfb09b/swiftenv-install.sh)"
       script:
         - swift build --verbose
         - swift test || true
-git:
-  submodules: false
-before_install:
-  - git submodule update --init --recursive
+    - os: linux
+      language: generic
+      sudo: required
+      dist: trusty
+      env:
+        - SWIFT_VERSION="3.1.1"
+      git:
+        submodules: false
+      before_install:
+        - eval "$(curl -sL https://gist.githubusercontent.com/kylef/5c0475ff02b7c7671d2a/raw/9f442512a46d7a2af7b850d65a7e9bd31edfb09b/swiftenv-install.sh)"
+      script:
+        - swift build --verbose
+        - swift test || true
 script:
   - xcodebuild ${XCODE_ACTION}
       -project PrettyColors.xcodeproj


### PR DESCRIPTION
- Add Xcode 8.3 and Xcode 9 jobs
- Remove redundant Xcode 8 and Xcode 8.1 jobs
- Remove redundant Swift 3.0 and Swift 3.0.1 jobs on Linux
- Explicit `git submodule update --init --recursive` is not needed anymore
- Submodules are not needed for SwiftPM